### PR TITLE
Feature/output option only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Forest Terraform
+# Contributing to sonar-scanner-action
 
 We'd love for you to contribute to our source code and to make the Forest even better than it is today! Here are the guidelines we'd like you to follow:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,138 @@
-# Contributing	
+# Contributing to Forest Terraform
 
-If by chance you would like to add or modify a feature for the greater good, feel free to create a pull request with your changes on this repository. Here are a few guidelines you need to take into account.
+We'd love for you to contribute to our source code and to make the Forest even better than it is today! Here are the guidelines we'd like you to follow:
 
-1. Add unittests that prove your new functionality works.
-2. Format your code using Prettier and the configuration that is included in this package
-3. Ensure your IDE adheres to the EditorConfig file that is included in this package
-4. Update the README.md with details of changes to the interface, this includes new input and potential outputs.
-5. Increase the version numbers in package.json. The versioning scheme we use is [SemVer](http://semver.org/).
+ - [Question or Problem?](#question)
+ - [Issues and Bugs](#issue)
+ - [Feature Requests](#feature)
+ - [Submission Guidelines](#submit)
+ - [Further Info](#info)
+
+## <a name="question"></a> Got a Question or Problem?
+
+If you have questions about how to use the Forest, please direct these to the [Slack group / philips-software][slack].
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
+
+## <a name="issue"></a> Found an Issue?
+
+If you find a bug in the source code or a mistake in the documentation, you can help us by submitting an issue to our [Github Repository][github]. Even better you can submit a Pull Request with a fix.
+
+**Please see the [Submission Guidelines](#submit) below.**
+
+## <a name="feature"></a> Want a Feature?
+
+You can request a new feature by submitting an issue to our [Github Repository][github]. If you would like to implement a new feature then consider what kind of change it is:
+
+* **Major Changes** that you wish to contribute to the project should be discussed first on our [Slack group][slack] so that we can better coordinate our efforts, prevent duplication of work, and help you to craft the change so that it is successfully accepted into the project.
+* **Small Changes** can be crafted and submitted to the [Github Repository][github] as a Pull Request.
+
+
+## <a name="docs"></a> Want a Doc Fix?
+
+If you want to help improve the docs, it's a good idea to let others know what you're working on to minimize duplication of effort. Create a new issue (or comment on a related existing one) to let others know what you're working on.
+
+For large fixes, please build and test the documentation before submitting the MR to be sure you haven't accidentally introduced any layout or formatting issues. You should also make sure that your commit message starts with "docs" and follows the **[Commit Message Guidelines](#commit)** outlined below.
+
+## <a name="submit"></a> Submission Guidelines
+
+### Submitting an Issue
+Before you submit your issue search the archive, maybe your question was already answered.
+
+If your issue appears to be a bug, and hasn't been reported, open a new issue. Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues. Providing the following information will increase the chances of your issue being dealt with quickly:
+
+* **Overview of the Issue** - if an error is being thrown a non-minified stack trace helps
+* **Motivation for or Use Case** - explain why this is a bug for you
+* **Forest Version(s)** - is it a regression?
+* **Reproduce the Error** - try to describe how to reproduce the error
+* **Related Issues** - has a similar issue been reported before?
+* **Suggest a Fix** - if you can't fix the bug yourself, perhaps you can point to what might be
+  causing the problem (line of code or commit)
+
+**If you get help, help others. Good karma rulez!**
+
+### Submitting a Merge Request
+Before you submit your merge request consider the following guidelines:
+
+* Make your changes in a new git branch:
+
+    ```shell
+    git checkout -b my-fix-branch master
+    ```
+
+* Create your patch, **including appropriate test cases**.
+* Run the test suite and ensure that all tests pass.
+* Add a line in the CHANGELOG.md under Unreleased. This will be used form generating the release notes.
+* Commit your changes using a descriptive commit message.
+
+    ```shell
+    git commit -a
+    ```
+  Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
+
+* Build your changes locally to ensure all the tests pass:
+* Push your branch to Github:
+
+    ```shell
+    git push origin my-fix-branch
+    ```
+
+In Github, send a pull request to original master branch: f.e. `terraform-aws-vpc:master`.
+If we suggest changes, then:
+
+* Make the required updates.
+* Re-run the test suite to ensure tests are still passing.
+* Commit your changes to your branch (e.g. `my-fix-branch`).
+* Push the changes to your Github repository (this will update your Pull Request).
+
+If the PR gets too outdated we may ask you to rebase and force push to update the PR:
+
+```shell
+git rebase master -i
+git push origin my-fix-branch -f
+```
+
+_WARNING: Squashing or reverting commits and force-pushing thereafter may remove Github comments on code that were previously made by you or others in your commits. Avoid any form of rebasing unless necessary._
+
+That's it! Thank you for your contribution!
+
+#### After your merge request is merged
+
+After your pull request is merged, you can safely delete your branch and pull the changes
+from the main (upstream) repository:
+
+* Delete the remote branch on Github either through the Github web UI or your local shell as follows:
+
+    ```shell
+    git push origin --delete my-fix-branch
+    ```
+
+* Check out the master branch:
+
+    ```shell
+    git checkout master -f
+    ```
+
+* Delete the local branch:
+
+    ```shell
+    git branch -D my-fix-branch
+    ```
+
+* Update your master with the latest upstream version:
+
+    ```shell
+    git pull --ff upstream master
+    ```
+
+## <a name="info"></a> Info
+
+For more info, please reach out to the team on [Slack group / philips-software][slack] in the #forest channel.
+
+Use the badge to sign-up.
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
+
+[contribute]: CONTRIBUTING.md
+[github]: https://github.com/philips-software/terraform-aws-ecs/issues 
+[slack]: https://philips-software.slack.com/home

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,2 +1,2 @@
-Matric Mennen <patrick.mennen@philips.com>
+Patrick Mennen <patrick.mennen@philips.com>
 Niek Palm <niek.palm@philips.com>

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,2 @@
+Matric Mennen <patrick.mennen@philips.com>
+Niek Palm <niek.palm@philips.com>

--- a/README.MD
+++ b/README.MD
@@ -1,54 +1,93 @@
 # Sonar Scanner Action
 
-A Github action for running static analysis on your codebase using SonarQube inside a Docker container.
+A GitHub action to configure and run the SonarQube scanner inside a [SonarQube Docker container](https://hub.docker.com/r/philipssoftware/sonar-scanner).
 
-## Required parameters
+The action support the following features
+- Configure scanner
+- Configure scanner for pull request decoration
+- Run sonar scanner
+- Export scanner configuration for consuming by e.g. `gradle`, `maven`.
 
-| Parameter                   | Description                                                              | required | default |
-| --------------------------- | :----------------------------------------------------------------------- | -------- | ------- |
-| projectName                 | Your application's name in SonarQube                                     | yes      |         |
-| projectKey                  | Unique value for your project in SonarQube                               | yes      |         |
-| baseDir                     | Relative path to your sonar.properties file (default: `.`)               | no       | `.`     |
-| token                       | SonarQube login token                                                    | yes      |         |
-| url                         | SonarQube server url                                                     | yes      |         |
-| scmProvider                 | SCM provider                                                             | no       | `git`   |
-| sourceEncoding              | Encoding of the source files                                             | no       | `UTF-8` |
-| enablePullRequestDecoration | Decorate a pull request. PR, branch and base are extracted from the pull | no       | `false` |
+## Action input parameters
 
+| Parameter                   | Description                                                                                           | required | default |
+| --------------------------- | :---------------------------------------------------------------------------------------------------- | -------- | ------- |
+| projectName                 | Your application's name in SonarQube                                                                  | yes      |         |
+| projectKey                  | Unique value for your project in SonarQube                                                            | yes      |         |
+| baseDir                     | Relative path to your sonar.properties file (default: `.`)                                            | no       | `.`     |
+| token                       | SonarQube login token                                                                                 | yes      |         |
+| url                         | SonarQube server url                                                                                  | yes      |         |
+| scmProvider                 | SCM provider                                                                                          | no       | `git`   |
+| sourceEncoding              | Encoding of the source files                                                                          | no       | `UTF-8` |
+| enablePullRequestDecoration | Decorate a pull request. PR, branch and base are extracted from the pull                              | no       | `false` |
+| onlyConfig                  | "Generate sonar configuration, scanner will not be invoked. Sonar parameters are available as output. | no       | `false` |
+
+## Action output parameters
+
+| Parameter       | Description                             |
+| --------------- | :-------------------------------------- |
+| sonarParameters | Sonar parameters generate based on inpu |
+
+sonarParameters:
+    description: Sonar parameters generate based on input.
 ## Sample Configuration
 
 To prevent your token from showing in the runner's output, it is advised to store the token configuration inside of a github secret variable.
 
 The listing below uses the secret `SONARQUBE_TOKEN` from your project's configuration.
 
+### Invoke the scanner without pull request decoration
 ```yml
 sonarqube:
   name: SonarQube
   runs-on: self-hosted
   steps:
-    - uses: philips-labs/sonar-scanner-action@v1
+    - uses: philips-labs/sonar-scanner-action@<version>
       with:
         token: ${{ secrets.SONARQUBE_TOKEN }}
         projectName: My Project Name
         projectKey: project.key.from.sonar.qube
+        baseDir: .
         url: https://your.sonar.instance.io/
 ```
 
-An example for decorating a pull request looks as follow.
+### Invoke the scanner with pull request decoration
 
 ```yml
-on:
-  push:
-  pull_request:
 
   name: SonarQube
   runs-on: self-hosted
   steps:
-    - uses: philips-labs/sonar-scanner-action@v1
+    - uses: philips-labs/sonar-scanner-action@<version>
       with:
         token: ${{ secrets.SONARQUBE_TOKEN }}
         projectName: My Project Name
         projectKey: project.key.from.sonar.qube
         url: https://your.sonar.instance.io/
         enablePullRequestDecoration: true
+```
+
+### Create configuration for the scanner with pull request decoration
+
+```yml
+
+  name: SonarQube
+  runs-on: self-hosted
+  steps:
+    - name: Configure sonar scanner
+      uses: philips-labs/sonar-scanner-action@<version>
+      id: sonarconfig
+      with:
+        token: ${{ secrets.SONARQUBE_TOKEN }}
+        projectName: My Project Name
+        projectKey: project.key.from.sonar.qube
+        url: https://your.sonar.instance.io/
+        enablePullRequestDecoration: true
+    - name: Run sonar scanner
+        uses: docker://openjdk:11.0.6-jdk-slim
+        with:
+          entrypoint: bash
+          args:
+            -c "./gradlew --info sonarQube ${{ steps.sonarconfig.outputs.sonarParameters }}"
+
 ```

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
 
 outputs:
   sonarParameters:
-    description: Sonar paramters
+    description: Sonar parameters
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,6 @@ inputs:
   baseDir:
     description: "Project Base Directory"
     required: false
-    default: "."
 
   token:
     description: "Sonar Login Token"

--- a/action.yml
+++ b/action.yml
@@ -1,52 +1,53 @@
-name: 'SonarQube Scanner'
-description: 'Static Analysis using SonarQube'
-author: 'Forest Keepers'
+name: "SonarQube Scanner"
+description: "Static Analysis using SonarQube"
+author: "Forest Keepers"
 branding:
-  icon: 'activity'
-  color: 'green'
+  icon: "activity"
+  color: "green"
 
 inputs:
   projectName:
-    description: 'Sonar Project name'
+    description: "Sonar Project name"
     required: true
 
   projectKey:
-    description: 'Sonar Project Key'
+    description: "Sonar Project Key"
     required: true
 
   baseDir:
-    description: 'Project Base Directory'
+    description: "Project Base Directory"
     required: false
-    default: '.'
+    default: "."
 
   token:
-    description: 'Sonar Login Token'
+    description: "Sonar Login Token"
     required: true
 
   url:
-    description: 'Sonar Server url'
+    description: "Sonar Server url"
     required: true
 
   scmProvider:
-    description: 'SCM provider'
+    description: "SCM provider"
     required: false
-    default: 'git'
+    default: "git"
 
   sourceEncoding:
-    description: 'Encoding of the source files'
+    description: "Encoding of the source files"
     required: false
-    default: 'UTF-8'
+    default: "UTF-8"
 
   enablePullRequestDecoration:
-    description: 'Decorate a pull request. PR, branch and base are extracted from the pull request event'
+    description: "Decorate a pull request. PR, branch and base are extracted from the pull request event"
     required: false
 
-  onlyConfig
+  onlyConfig:
     required: false
     default: false
 
 outputs:
-  sonarParamters:
+  sonarParameters:
+    description: Sonar paramters
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -41,12 +41,13 @@ inputs:
     required: false
 
   onlyConfig:
+    description: "Generate sonar configuration, scanner will not be invoked. Sonar parameters are available as output"
     required: false
     default: false
 
 outputs:
   sonarParameters:
-    description: Sonar parameters
+    description: Sonar parameters generate based on input.
 
 runs:
   using: docker

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,13 @@ inputs:
     description: 'Decorate a pull request. PR, branch and base are extracted from the pull request event'
     required: false
 
+  onlyConfig
+    required: false
+    default: false
+
+outputs:
+  sonarParamters:
+
 runs:
   using: docker
   image: Dockerfile

--- a/dist/index.js
+++ b/dist/index.js
@@ -2318,7 +2318,7 @@ exports.sonarScanner = async () => {
         `-Dsonar.scm.provider=${scmProvider}`,
         `-Dsonar.sourceEncoding=${sourceEncoding}`,
     ];
-    if (baseDir != undefined || baseDir != '') {
+    if (baseDir && baseDir.length > 0) {
         sonarParameters.push(`-Dsonar.projectBaseDir=${baseDir}`);
     }
     core.info(`

--- a/dist/index.js
+++ b/dist/index.js
@@ -2318,7 +2318,7 @@ exports.sonarScanner = async () => {
         `-Dsonar.scm.provider=${scmProvider}`,
         `-Dsonar.sourceEncoding=${sourceEncoding}`,
     ];
-    if (baseDir != undefined) {
+    if (baseDir != undefined || baseDir != '') {
         sonarParameters.push(`-Dsonar.projectBaseDir=${baseDir}`);
     }
     core.info(`

--- a/dist/index.js
+++ b/dist/index.js
@@ -2303,7 +2303,7 @@ function getBranchOrTagName(githubRef) {
 exports.sonarScanner = async () => {
     const projectName = core.getInput('projectName', { required: true });
     const projectKey = core.getInput('projectKey', { required: true });
-    const baseDir = core.getInput('baseDir', { required: true });
+    const baseDir = core.getInput('baseDir', { required: false });
     const token = core.getInput('token', { required: true });
     const url = core.getInput('url', { required: true });
     const scmProvider = core.getInput('scmProvider', { required: true });

--- a/dist/index.js
+++ b/dist/index.js
@@ -2315,7 +2315,7 @@ exports.sonarScanner = async () => {
         `-Dsonar.host.url=${url}`,
         `-Dsonar.projectBaseDir=${baseDir}`,
         `-Dsonar.projectKey=${projectKey}`,
-        `-Dsonar.projectName="${projectName}"`,
+        `-Dsonar.projectName=\"${projectName}\"`,
         `-Dsonar.scm.provider=${scmProvider}`,
         `-Dsonar.sourceEncoding=${sourceEncoding}`,
     ];

--- a/dist/index.js
+++ b/dist/index.js
@@ -2309,6 +2309,7 @@ exports.sonarScanner = async () => {
     const scmProvider = core.getInput('scmProvider', { required: true });
     const sourceEncoding = core.getInput('sourceEncoding', { required: false });
     const enablePullRequestDecoration = JSON.parse(core.getInput('enablePullRequestDecoration', { required: false }));
+    const onlyConfig = core.getInput('onlyConfig', { required: false });
     const sonarParameters = [
         `-Dsonar.login=${token}`,
         `-Dsonar.host.url=${url}`,
@@ -2350,14 +2351,19 @@ exports.sonarScanner = async () => {
         sonarParameters.push(`-Dsonar.pullrequest.base=${pr.base.ref}`);
         sonarParameters.push(`-Dsonar.pullrequest.branch=${pr.head.ref}`);
     }
-    core.startGroup('Running SonarQube');
-    core.debug(`Running SonarQube with parameters: ${sonarParameters.join(', ')}`);
-    const errorCode = await exec_1.exec('sonar-scanner', sonarParameters);
-    if (errorCode === 1) {
-        core.setFailed('SonarScanner failed.');
-        throw new Error('SonarScanner failed');
+    if (!onlyConfig) {
+        core.startGroup('Running SonarQube');
+        core.debug(`Running SonarQube with parameters: ${sonarParameters.join(', ')}`);
+        const errorCode = await exec_1.exec('sonar-scanner', sonarParameters);
+        if (errorCode === 1) {
+            core.setFailed('SonarScanner failed.');
+            throw new Error('SonarScanner failed');
+        }
+        core.endGroup();
     }
-    core.endGroup();
+    else {
+        core.setOutput('sonarParameters', sonarParameters.join(','));
+    }
 };
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2313,12 +2313,14 @@ exports.sonarScanner = async () => {
     const sonarParameters = [
         `-Dsonar.login=${token}`,
         `-Dsonar.host.url=${url}`,
-        `-Dsonar.projectBaseDir=${baseDir}`,
         `-Dsonar.projectKey=${projectKey}`,
         `-Dsonar.projectName=\'${projectName}\'`,
         `-Dsonar.scm.provider=${scmProvider}`,
         `-Dsonar.sourceEncoding=${sourceEncoding}`,
     ];
+    if (baseDir != undefined) {
+        sonarParameters.push(`-Dsonar.projectBaseDir=${baseDir}`);
+    }
     core.info(`
     Using Configuration:
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2315,7 +2315,7 @@ exports.sonarScanner = async () => {
         `-Dsonar.host.url=${url}`,
         `-Dsonar.projectBaseDir=${baseDir}`,
         `-Dsonar.projectKey=${projectKey}`,
-        `-Dsonar.projectName=${projectName}`,
+        `-Dsonar.projectName="${projectName}"`,
         `-Dsonar.scm.provider=${scmProvider}`,
         `-Dsonar.sourceEncoding=${sourceEncoding}`,
     ];

--- a/dist/index.js
+++ b/dist/index.js
@@ -2363,7 +2363,7 @@ exports.sonarScanner = async () => {
     }
     else {
         core.info('Skipping running scanner.');
-        core.setOutput('sonarParameters', sonarParameters.join(','));
+        core.setOutput('sonarParameters', sonarParameters.join(' '));
     }
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -2362,6 +2362,7 @@ exports.sonarScanner = async () => {
         core.endGroup();
     }
     else {
+        core.info('Skipping running scanner.');
         core.setOutput('sonarParameters', sonarParameters.join(','));
     }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -2315,7 +2315,7 @@ exports.sonarScanner = async () => {
         `-Dsonar.host.url=${url}`,
         `-Dsonar.projectBaseDir=${baseDir}`,
         `-Dsonar.projectKey=${projectKey}`,
-        `-Dsonar.projectName=\"${projectName}\"`,
+        `-Dsonar.projectName=\'${projectName}\'`,
         `-Dsonar.scm.provider=${scmProvider}`,
         `-Dsonar.sourceEncoding=${sourceEncoding}`,
     ];

--- a/src/sonarScanner-p.test.ts
+++ b/src/sonarScanner-p.test.ts
@@ -38,11 +38,11 @@ describe('SonarQube Scanner Action for a Pull Request', () => {
     expect(exec).toHaveBeenCalledWith('sonar-scanner', [
       '-Dsonar.login=Dummy-Security-Token',
       '-Dsonar.host.url=http://example.com',
-      '-Dsonar.projectBaseDir=.',
       '-Dsonar.projectKey=key',
-      '-Dsonar.projectName=HelloWorld',
+      "-Dsonar.projectName='HelloWorld'",
       '-Dsonar.scm.provider=git',
       '-Dsonar.sourceEncoding=UTF-8',
+      '-Dsonar.projectBaseDir=.',
       '-Dsonar.pullrequest.key=101',
       '-Dsonar.pullrequest.base=master',
       '-Dsonar.pullrequest.branch=feature/featureX',
@@ -56,11 +56,11 @@ describe('SonarQube Scanner Action for a Pull Request', () => {
     expect(exec).toHaveBeenCalledWith('sonar-scanner', [
       '-Dsonar.login=Dummy-Security-Token',
       '-Dsonar.host.url=http://example.com',
-      '-Dsonar.projectBaseDir=.',
       '-Dsonar.projectKey=key',
-      '-Dsonar.projectName=HelloWorld',
+      "-Dsonar.projectName='HelloWorld'",
       '-Dsonar.scm.provider=git',
       '-Dsonar.sourceEncoding=UTF-8',
+      '-Dsonar.projectBaseDir=.',
     ]);
   });
 });

--- a/src/sonarScanner.test.ts
+++ b/src/sonarScanner.test.ts
@@ -13,7 +13,7 @@ jest.mock('@actions/github', () => ({
 describe('SonarQube Scanner Action', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    process.env['INPUT_PROJECTNAME'] = 'HelloWorld';
+    process.env['INPUT_PROJECTNAME'] = 'Hello World';
     process.env['INPUT_PROJECTKEY'] = 'key';
     process.env['INPUT_TOKEN'] = 'Dummy-Security-Token';
     process.env['INPUT_URL'] = 'http://example.com';
@@ -42,16 +42,38 @@ describe('SonarQube Scanner Action', () => {
     },
   );
 
-  it('starts the action when all parameters are set', async () => {
+  it('starts the action when mandatory parameters are set', async () => {
     await sonarScanner();
     expect(exec).toHaveBeenCalledWith('sonar-scanner', [
       '-Dsonar.login=Dummy-Security-Token',
       '-Dsonar.host.url=http://example.com',
-      '-Dsonar.projectBaseDir=src/',
       '-Dsonar.projectKey=key',
-      '-Dsonar.projectName=HelloWorld',
+      "-Dsonar.projectName='Hello World'",
       '-Dsonar.scm.provider=git',
       '-Dsonar.sourceEncoding=UTF-8',
+      '-Dsonar.branch.name=develop',
+    ]);
+  });
+
+  // it('Skip invoking scanner, only config.', async () => {
+  //   process.env['INPUT_ONLYCONFIG'] = 'true';
+
+  //   await sonarScanner();
+  //   expect(exec).toHaveBeenCalledTimes(0);
+  // });
+
+  it('starts the action when baseDir  set', async () => {
+    process.env['INPUT_BASEDIR'] = 'src/';
+
+    await sonarScanner();
+    expect(exec).toHaveBeenCalledWith('sonar-scanner', [
+      '-Dsonar.login=Dummy-Security-Token',
+      '-Dsonar.host.url=http://example.com',
+      '-Dsonar.projectKey=key',
+      "-Dsonar.projectName='Hello World'",
+      '-Dsonar.scm.provider=git',
+      '-Dsonar.sourceEncoding=UTF-8',
+      '-Dsonar.projectBaseDir=src/',
       '-Dsonar.branch.name=develop',
     ]);
   });
@@ -71,18 +93,5 @@ describe('SonarQube Scanner Action', () => {
     } catch (e) {
       expect(e.message).toBe('SonarScanner failed');
     }
-  });
-
-  describe('Pull Request', () => {
-    beforeEach(() => {
-      jest.resetModules();
-      process.env['INPUT_PROJECTNAME'] = 'HelloWorld';
-      process.env['INPUT_PROJECTKEY'] = 'key';
-      process.env['INPUT_BASEDIR'] = '.';
-      process.env['INPUT_TOKEN'] = 'Dummy-Security-Token';
-      process.env['INPUT_URL'] = 'http://example.com';
-      process.env['INPUT_SCMPROVIDER'] = 'git';
-      process.env['INPUT_SOURCEENCODING'] = 'UTF-8';
-    });
   });
 });

--- a/src/sonarScanner.test.ts
+++ b/src/sonarScanner.test.ts
@@ -20,6 +20,7 @@ describe('SonarQube Scanner Action', () => {
     process.env['INPUT_SCMPROVIDER'] = 'git';
     process.env['INPUT_SOURCEENCODING'] = 'UTF-8';
     process.env['INPUT_ENABLEPULLREQUESTDECORATION'] = 'false';
+    delete process.env['INPUT_ONLYCONFIG'];
   });
 
   it.each`
@@ -55,13 +56,6 @@ describe('SonarQube Scanner Action', () => {
     ]);
   });
 
-  // it('Skip invoking scanner, only config.', async () => {
-  //   process.env['INPUT_ONLYCONFIG'] = 'true';
-
-  //   await sonarScanner();
-  //   expect(exec).toHaveBeenCalledTimes(0);
-  // });
-
   it('starts the action when baseDir  set', async () => {
     process.env['INPUT_BASEDIR'] = 'src/';
 
@@ -76,6 +70,13 @@ describe('SonarQube Scanner Action', () => {
       '-Dsonar.projectBaseDir=src/',
       '-Dsonar.branch.name=develop',
     ]);
+  });
+
+  it('Skip invoking scanner, only config.', async () => {
+    process.env['INPUT_ONLYCONFIG'] = 'true';
+
+    await sonarScanner();
+    expect(exec).not.toHaveBeenCalled();
   });
 
   it('throws an error when SonarQube fails', async () => {

--- a/src/sonarScanner.test.ts
+++ b/src/sonarScanner.test.ts
@@ -15,7 +15,6 @@ describe('SonarQube Scanner Action', () => {
     jest.resetAllMocks();
     process.env['INPUT_PROJECTNAME'] = 'HelloWorld';
     process.env['INPUT_PROJECTKEY'] = 'key';
-    process.env['INPUT_BASEDIR'] = 'src/';
     process.env['INPUT_TOKEN'] = 'Dummy-Security-Token';
     process.env['INPUT_URL'] = 'http://example.com';
     process.env['INPUT_SCMPROVIDER'] = 'git';

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -80,6 +80,7 @@ export const sonarScanner = async () => {
 
     core.endGroup();
   } else {
+    core.info('Skipping running scanner.');
     core.setOutput('sonarParameters', sonarParameters.join(','));
   }
 };

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -25,7 +25,7 @@ export const sonarScanner = async () => {
     `-Dsonar.host.url=${url}`,
     `-Dsonar.projectBaseDir=${baseDir}`,
     `-Dsonar.projectKey=${projectKey}`,
-    `-Dsonar.projectName=${projectName}`,
+    `-Dsonar.projectName="${projectName}"`,
     `-Dsonar.scm.provider=${scmProvider}`,
     `-Dsonar.sourceEncoding=${sourceEncoding}`,
   ];

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -10,7 +10,7 @@ function getBranchOrTagName(githubRef: string): string {
 export const sonarScanner = async () => {
   const projectName = core.getInput('projectName', { required: true });
   const projectKey = core.getInput('projectKey', { required: true });
-  const baseDir = core.getInput('baseDir', { required: true });
+  const baseDir = core.getInput('baseDir', { required: false });
   const token = core.getInput('token', { required: true });
   const url = core.getInput('url', { required: true });
   const scmProvider = core.getInput('scmProvider', { required: true });

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -29,7 +29,7 @@ export const sonarScanner = async () => {
     `-Dsonar.sourceEncoding=${sourceEncoding}`,
   ];
 
-  if (baseDir != undefined) {
+  if (baseDir != undefined || baseDir != '') {
     sonarParameters.push(`-Dsonar.projectBaseDir=${baseDir}`);
   }
 

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -25,7 +25,7 @@ export const sonarScanner = async () => {
     `-Dsonar.host.url=${url}`,
     `-Dsonar.projectBaseDir=${baseDir}`,
     `-Dsonar.projectKey=${projectKey}`,
-    `-Dsonar.projectName="${projectName}"`,
+    `-Dsonar.projectName=\"${projectName}\"`,
     `-Dsonar.scm.provider=${scmProvider}`,
     `-Dsonar.sourceEncoding=${sourceEncoding}`,
   ];

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -81,6 +81,6 @@ export const sonarScanner = async () => {
     core.endGroup();
   } else {
     core.info('Skipping running scanner.');
-    core.setOutput('sonarParameters', sonarParameters.join(','));
+    core.setOutput('sonarParameters', sonarParameters.join(' '));
   }
 };

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -25,7 +25,7 @@ export const sonarScanner = async () => {
     `-Dsonar.host.url=${url}`,
     `-Dsonar.projectBaseDir=${baseDir}`,
     `-Dsonar.projectKey=${projectKey}`,
-    `-Dsonar.projectName=\"${projectName}\"`,
+    `-Dsonar.projectName=\'${projectName}\'`,
     `-Dsonar.scm.provider=${scmProvider}`,
     `-Dsonar.sourceEncoding=${sourceEncoding}`,
   ];

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -23,12 +23,15 @@ export const sonarScanner = async () => {
   const sonarParameters: string[] = [
     `-Dsonar.login=${token}`,
     `-Dsonar.host.url=${url}`,
-    `-Dsonar.projectBaseDir=${baseDir}`,
     `-Dsonar.projectKey=${projectKey}`,
     `-Dsonar.projectName=\'${projectName}\'`,
     `-Dsonar.scm.provider=${scmProvider}`,
     `-Dsonar.sourceEncoding=${sourceEncoding}`,
   ];
+
+  if (baseDir != undefined) {
+    sonarParameters.push(`-Dsonar.projectBaseDir=${baseDir}`);
+  }
 
   core.info(`
     Using Configuration:

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -18,6 +18,7 @@ export const sonarScanner = async () => {
   const enablePullRequestDecoration = JSON.parse(
     core.getInput('enablePullRequestDecoration', { required: false }),
   );
+  const onlyConfig = core.getInput('onlyConfig', { required: false });
 
   const sonarParameters: string[] = [
     `-Dsonar.login=${token}`,
@@ -65,16 +66,20 @@ export const sonarScanner = async () => {
     sonarParameters.push(`-Dsonar.pullrequest.branch=${pr.head.ref}`);
   }
 
-  core.startGroup('Running SonarQube');
-  core.debug(
-    `Running SonarQube with parameters: ${sonarParameters.join(', ')}`,
-  );
-  const errorCode = await exec('sonar-scanner', sonarParameters);
+  if (!onlyConfig) {
+    core.startGroup('Running SonarQube');
+    core.debug(
+      `Running SonarQube with parameters: ${sonarParameters.join(', ')}`,
+    );
+    const errorCode = await exec('sonar-scanner', sonarParameters);
 
-  if (errorCode === 1) {
-    core.setFailed('SonarScanner failed.');
-    throw new Error('SonarScanner failed');
+    if (errorCode === 1) {
+      core.setFailed('SonarScanner failed.');
+      throw new Error('SonarScanner failed');
+    }
+
+    core.endGroup();
+  } else {
+    core.setOutput('sonarParameters', sonarParameters.join(','));
   }
-
-  core.endGroup();
 };

--- a/src/sonarScanner.ts
+++ b/src/sonarScanner.ts
@@ -29,7 +29,7 @@ export const sonarScanner = async () => {
     `-Dsonar.sourceEncoding=${sourceEncoding}`,
   ];
 
-  if (baseDir != undefined || baseDir != '') {
+  if (baseDir && baseDir.length > 0) {
     sonarParameters.push(`-Dsonar.projectBaseDir=${baseDir}`);
   }
 


### PR DESCRIPTION
Adding an option to only generate the configuration for sonar and export it as output. This gives other process the advantage of the logic of action. For example mvn, gradle or other build tools can leverage the settings for sonar for branch and pr decoration.